### PR TITLE
Small class, method changes

### DIFF
--- a/dspace.py
+++ b/dspace.py
@@ -45,7 +45,7 @@ class DSpaceObject:
         """
 
         self.type = None
-        self.metadata = {}
+        self.metadata = dict()
 
         if dso is not None:
             api_resource = dso.as_dict()
@@ -163,8 +163,9 @@ class Item(SimpleDSpaceObject):
         if dso is not None:
             api_resource = dso.as_dict()
 
+        super(Item, self).__init__(api_resource)
+
         if api_resource is not None:
-            super(Item, self).__init__(api_resource)
             self.type = 'item'
             self.inArchive = api_resource['inArchive'] if 'inArchive' in api_resource else False
             self.discoverable = api_resource['discoverable'] if 'discoverable' in api_resource else False

--- a/dspace.py
+++ b/dspace.py
@@ -666,18 +666,28 @@ class DSpaceClient:
             url = dso.links['self']['href']
             # Get and clean data - there are some unalterable fields that could cause errors
             data = dso.as_dict()
-            data.pop('lastModified')
-            data.pop('id')
-            data.pop('handle')
-            data.pop('uuid')
-            data.pop('type')
+
+            if 'lastModified' in data:
+                data.pop('lastModified')
+            """
+            if 'id' in data:
+                data.pop('id')
+            if 'handle' in data:
+                data.pop('handle')
+            if 'uuid' in data:
+                data.pop('uuid')
+            if 'type' in data:
+                data.pop('type')
+            """
             r = self.api_put(url, params=params, json=data)
             if r.status_code == 200:
                 # 200 OK - success!
                 updated_dso = dso_type(parse_json(r))
                 print(f'{updated_dso.type} {updated_dso.uuid} updated sucessfully!')
+                return updated_dso
             else:
                 print(f'update operation failed: {r.status_code}: {r.text} ({url})')
+                return None
 
         except ValueError as e:
             print(f'{e}')
@@ -962,8 +972,7 @@ class DSpaceClient:
         if not isinstance(item, Item):
             print('Need a valid item')
             return None
-        url = f'{self.API_ENDPOINT}/core/items/{item.uuid}'
-        return Item(api_resource=parse_json(self.update_dso(url, params=None, data=item.as_dict())))
+        return self.update_dso(item, params=None)
 
     def add_metadata(self, dso, field, value, language=None, authority=None, confidence=-1, place=''):
         """

--- a/example.py
+++ b/example.py
@@ -55,6 +55,15 @@ else:
     print(f'Error! Giving up.')
     exit(1)
 
+# Update the community metadata
+new_community.name = 'Community created by the Python REST Client - Updated Name'
+new_community.metadata['dc.title'][0] = {
+    'value': 'Community created by the Python REST Client - Updated Name',
+    'language': 'en', 'authority': None, 'confidence': -1
+}
+
+d.update_dso(new_community)
+
 # Put together some basic Collection data.
 # See https://github.com/DSpace/RestContract/blob/main/collections.md
 collection_data = {
@@ -133,6 +142,10 @@ if isinstance(new_item, Item) and new_item.uuid is not None:
 else:
     print(f'Error! Giving up.')
     exit(1)
+
+# Add a single metadata field+value to the item (PATCH operation)
+updated_item = d.add_metadata(dso=new_item, field='dc.description.abstract', value='Added abstract to an existing item',
+                              language='en', authority=None, confidence=-1)
 
 # Create a new ORIGINAL bundle
 # See https://github.com/DSpace/RestContract/blob/main/bundles.md


### PR DESCRIPTION
Various fixes:
* Refactored class hierarchy for various DSpace Objects
* `Item` will always call super `__init__` even if passed empty data. This ensures new items won't accidentally use a class static metadata dict, and will have all members properly instantiated in `DSpaceObject.__init__`
* `update_dso` made more stable and `update_item` updated to call it properly