### PR TITLE
Fixes #13: Correct content type header for URI lists

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -107,7 +107,7 @@ class DSpaceClient:
         # Set headers based on this
         self.auth_request_headers = {'User-Agent': self.USER_AGENT}
         self.request_headers = {'Content-type': 'application/json', 'User-Agent': self.USER_AGENT}
-        self.list_request_headers = {'Content-type': 'text-uri-list', 'User-Agent': self.USER_AGENT}
+        self.list_request_headers = {'Content-type': 'text/uri-list', 'User-Agent': self.USER_AGENT}
 
     def authenticate(self, retry=False):
         """


### PR DESCRIPTION
Change content-type header for URI lists from "text-uri-list" to "text/uri-list" as per https://github.com/DSpace/RestContract/tree/84ab1168ac855639e4fd2c43a916bd29d33e7eb5?tab=readme-ov-file#on-sub-path-of-a-single-resource-endpoint-associations