### PR TITLE
#18: Allow embed=[] in methods and embed resources in response

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -962,7 +962,7 @@ class DSpaceClient:
         # TODO: To be consistent with other create methods, this should probably also allow a Community object
         #  to be passed instead of just the UUID as a string
         url = f'{self.API_ENDPOINT}/core/collections'
-        params = parse_params(embeds=embed)
+        params = parse_params(embeds=embeds)
         if parent is not None:
             params = {'parent': parent}
         return Collection(api_resource=parse_json(self.create_dso(url, params, data)))
@@ -1058,7 +1058,7 @@ class DSpaceClient:
 
         return None
 
-    def update_item(self, item):
+    def update_item(self, item, embeds=None):
         """
         Update item. The Item passed to this method contains all the data, identifiers, links necessary to
         perform the update to the API. Note this is a full update, not a patch / partial update operation.

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -665,7 +665,7 @@ class DSpaceClient:
         return Bundle(api_resource=parse_json(self.api_post(url, params=None, json={'name': name, 'metadata': {}})))
 
     # PAGINATION
-    def get_bitstreams(self, uuid=None, bundle=None, page=0, size=20, sort=None):
+    def get_bitstreams(self, uuid=None, bundle=None, page=0, size=20, sort=None, embeds=None):
         """
         Get a specific bitstream UUID, or all bitstreams for a specific bundle
         @param uuid:    UUID of a specific bitstream to retrieve
@@ -674,6 +674,8 @@ class DSpaceClient:
         @param size:    Size of results per page (default: 20)
         @return:        list of python Bitstream objects
         """
+        if embeds is None:
+            embeds = []
         url = f'{self.API_ENDPOINT}/core/bitstreams/{uuid}'
         if uuid is None and bundle is None:
             return list()
@@ -691,12 +693,15 @@ class DSpaceClient:
             params['page'] = page
         if sort is not None:
             params['sort'] = sort
+        if len(embeds) > 0:
+            params['embed'] = ','.join(embeds)
         r_json = self.fetch_resource(url, params=params)
         if '_embedded' in r_json:
             if 'bitstreams' in r_json['_embedded']:
                 bitstreams = list()
                 for bitstream_resource in r_json['_embedded']['bitstreams']:
-                    bitstreams.append(Bitstream(bitstream_resource))
+                    bitstream = Bitstream(bitstream_resource)
+                    bitstreams.append(bitstream)
                 return bitstreams
 
     @paginated('bitstreams', Bitstream)

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -12,7 +12,7 @@ when creating, updating, retrieving and deleting DSpace Objects.
 import json
 
 __all__ = ['DSpaceObject', 'HALResource', 'ExternalDataObject', 'SimpleDSpaceObject', 'Community',
-           'Collection', 'Item', 'Bundle', 'Bitstream', 'User', 'Group']
+           'Collection', 'Item', 'Bundle', 'Bitstream', 'BitstreamFormat', 'User', 'Group']
 
 
 class HALResource:
@@ -21,6 +21,7 @@ class HALResource:
     """
     links = {}
     type = None
+    embedded = dict()
 
     def __init__(self, api_resource=None):
         """
@@ -32,6 +33,8 @@ class HALResource:
                 self.type = api_resource['type']
             if '_links' in api_resource:
                 self.links = api_resource['_links'].copy()
+            if '_embedded' in api_resource:
+                self.embedded = api_resource['_embedded'].copy()
             else:
                 self.links = {'self': {'href': None}}
 
@@ -378,6 +381,57 @@ class Bitstream(DSpaceObject):
                           'sequenceId': self.sequenceId}
         return {**dso_dict, **bitstream_dict}
 
+class BitstreamFormat(AddressableHALResource):
+    """
+    Bitstream format: https://github.com/DSpace/RestContract/blob/main/bitstreamformats.md
+    example:
+        {
+          "shortDescription": "XML",
+          "description": "Extensible Markup Language",
+          "mimetype": "text/xml",
+          "supportLevel": "KNOWN",
+          "internal": false,
+          "extensions": [
+                  "xml"
+          ],
+          "type": "bitstreamformat"
+        }
+    """
+    shortDescription = None
+    description = None
+    mimetype = None
+    supportLevel = None
+    internal = False
+    extensions = []
+    type = 'bitstreamformat'
+
+    def __init__(self, api_resource):
+        super(BitstreamFormat, self).__init__(api_resource)
+        if 'shortDescription' in api_resource:
+            self.shortDescription = api_resource['shortDescription']
+        if 'description' in api_resource:
+            self.description = api_resource['description']
+        if 'mimetype' in api_resource:
+            self.mimetype = api_resource['mimetype']
+        if 'supportLevel' in api_resource:
+            self.supportLevel = api_resource['supportLevel']
+        if 'internal' in api_resource:
+            self.internal = api_resource['internal']
+        if 'extensions' in api_resource:
+            self.extensions = api_resource['extensions'].copy()
+
+    def as_dict(self):
+        parent_dict = super(BitstreamFormat, self).as_dict()
+        dict = {
+            'shortDescription': self.shortDescription,
+            'description': self.description,
+            'mimetype': self.mimetype,
+            'supportLevel': self.supportLevel,
+            'internal': self.internal,
+            'extensions': self.extensions,
+            'type': self.type
+        }
+        return {**parent_dict, **dict}
 
 class Group(DSpaceObject):
     """

--- a/example.py
+++ b/example.py
@@ -6,6 +6,7 @@
 Example Python 3 application using the dspace.py API client library to create
 some resources in a DSpace 7 repository.
 """
+from pprint import pprint
 
 from dspace_rest_client.client import DSpaceClient
 from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
@@ -70,7 +71,10 @@ new_community.metadata['dc.title'][0] = {
     'language': 'en', 'authority': None, 'confidence': -1
 }
 
-d.update_dso(new_community)
+# Linked resources can be embedded with responses, e.g.
+updated_community = d.update_dso(new_community, embeds=['logo', 'collections'])
+# Print logo (it'll be None in this case, but just an example
+print(f"Logo for updated community is {updated_community.embedded['logo']}")
 
 # Put together some basic Collection data.
 # See https://github.com/DSpace/RestContract/blob/main/collections.md


### PR DESCRIPTION
@alanorth This is one way of fixing #18 -- I am interested to hear if you think it's the right approach.

We can request linked HAL stuff to be embedded in the parent object using `?embed=...` in the REST API call. So this change allows a client to say `bitstreams = d.get_bitstreams(bundle=my_bundle, embeds=['format'])`, and then in the resulting Bitstream objects you can get format out like `format = BitstreamFormat(bitstream.embedded['format'])` without any additional API calls.

The only thing I wasn't sure about is if we should handle that in the client lib instead of making the actual client do it... this way keeps things relatively simple in the library, we don't have to know anything in the bitstream model because it'll just copy all _embedded JSON into a dict. If we wanted to make that model more 'smart' we'd tell it what kind of embeds to expect, and we could parse and instantiate the BitstreamFormat objects before handing back in the get_bitstreams() return value. 

Here is my example script to test it out:

```
import pprint

from dspace_rest_client.client import DSpaceClient
from dspace_rest_client.models import BitstreamFormat

# Authenticate against the DSpace client
authenticated = d.authenticate()
if not authenticated:
    print('Error logging in! Giving up.')
    exit(1)

print('\nExample of ORIGINAL bundle output with format embedded.\n')
# Get top communities
top_communities = d.get_communities(top=True)
for top_community in top_communities:
    # Get all collections in this community
    collections = d.get_collections(community=top_community)
    for collection in collections:
        # Get all items in this collection - see that the recommended method is a search, scoped to this collection
        # (there is no collection/items endpoint, though there is a /mappedItems endpoint, not yet implemented here)
        items = d.search_objects(query='*:*', scope=collection.uuid, dso_type='item')
        for item in items:
            print(f'{item.name} ({item.uuid})')
            # Get all bundles in this item
            bundles = d.get_bundles(parent=item)
            for bundle in bundles:
                if bundle.name == 'ORIGINAL':
                    print(f'\n\nBUNDLE {bundle.name} ({bundle.uuid})')
                    # Get all bitstreams in this bundle
                    bitstreams = d.get_bitstreams(bundle=bundle, embeds=['format'])
                    for bitstream in bitstreams:
                        print(f'{bitstream.name} ({bitstream.uuid})')
                        if 'format' in bitstream.embedded:
                            format = BitstreamFormat(bitstream.embedded['format'])
                            pprint.pp(format.as_dict())
```