### PR TITLE
Fix wrong if-statement in get_items

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -844,7 +844,7 @@ class DSpaceClient:
         items = list()
         if '_embedded' in r_json:
             # This is a list of items
-            if 'collections' in r_json['_embedded']:
+            if 'items' in r_json['_embedded']:
                 for item_resource in r_json['_embedded']['items']:
                     items.append(Item(item_resource))
         elif 'uuid' in r_json:


### PR DESCRIPTION
Fixes a wrong if-statement in get_items that lead to an always empty list. The statement checked for the dictionary key 'collections' which is never there and always returns false. The correct way is to check for the 'items' key.