### PR TITLE
Minor updates to Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests~=2.27.1
-pysolr~=3.9.0
+requests~=2.32.3
+pysolr~=3.10.0
 setuptools~=47.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=["dspace_rest_client"],
-    install_requires=["requests >= 2.27.1",
-                      "pysolr >= 3.9.0"],
+    install_requires=["requests >= 2.32.3",
+                      "pysolr >= 3.10.0"],
     python_requires=">=3.8.0",
 )

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setuptools.setup(
         'Changelog': 'https://github.com/the-library-code/dspace-rest-python/blob/main/CHANGELOG.md',
     },
     classifiers=[
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This updates requests and pysolr, as well as a minor update to the classifiers in `setup.py`.

Long term you should look at migrating to a `pyproject.toml` file with rye or uv instead of separately (and manually) maintaining `setup.py` and `requirements.txt`. Pipenv and poetry are also options, but they don't use PEP-621 compatible project files, and are slower than rye and uv.