### PR TITLE
Add auto-paginating `get_*_iter` methods for most `get_*` methods

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -794,13 +794,17 @@ class DSpaceClient:
 
     # TODO: does top paginate the same way?
     @paginated('communities', Community)
-    def get_communities_iter(self, sort=None, top=False):
+    def get_communities_iter(do_paginate, self, sort=None, top=False):
         """
         Get communities as an iterator, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param top:     whether to restrict search to top communities (default: false)
         @return: Iterator of Community
         """
-        url = f'{self.API_ENDPOINT}/core/communities'
+        if top:
+            url = f'{url}/core/communities/search/top'
+        else:
+            url = f'{self.API_ENDPOINT}/core/communities'
+
         params = {}
         if sort is not None:
             params['sort'] = sort

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -84,6 +84,13 @@ class DSpaceClient:
         MOVE = 'move'
 
     def paginated(embed_name, item_constructor, embedding=lambda x: x):
+        """
+        @param embed_name: The key under '_embedded' in the JSON response that contains the resources to be paginated.
+                           (e.g. 'collections', 'objects', 'items', etc.)
+        @param item_constructor: A callable that takes a resource dictionary and returns an item.
+        @param embedding: Optional post-fetch processing lambda (default: identity function) for each resource
+        @return: A decorator that, when applied to a method, follows pagination and yields each resource
+        """
         def decorator(fun):
             @functools.wraps(fun)
             def decorated(self, *args, **kwargs):
@@ -1096,6 +1103,7 @@ class DSpaceClient:
         @return:     Iterator of User
         """
         url = f'{self.API_ENDPOINT}/eperson/epersons'
+        params = {}
         if sort is not None:
             params['sort'] = sort
 

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -792,7 +792,6 @@ class DSpaceClient:
         # Return list (populated or empty)
         return communities
 
-    # TODO: does top paginate the same way?
     @paginated('communities', Community)
     def get_communities_iter(do_paginate, self, sort=None, top=False):
         """

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -1066,6 +1066,12 @@ class DSpaceClient:
 
     # PAGINATION
     def get_users(self, page=0, size=20, sort=None):
+        """
+        Get a list of users (epersons) in the DSpace instance
+        @param page: Integer for page / offset of results. Default: 0
+        @param size: Integer for page size. Default: 20 (same as REST API default)
+        @return:     list of User objects
+        """
         url = f'{self.API_ENDPOINT}/eperson/epersons'
         users = list()
         params = {}
@@ -1082,6 +1088,18 @@ class DSpaceClient:
                 for user_resource in r_json['_embedded']['epersons']:
                     users.append(User(user_resource))
         return users
+
+    @paginated('epersons', User)
+    def get_users_iter(do_paginate, self, sort=None):
+        """
+        Get an iterator of users (epersons) in the DSpace instance, automatically handling pagination by requesting the next page when all items from one page have been consumed
+        @return:     Iterator of User
+        """
+        url = f'{self.API_ENDPOINT}/eperson/epersons'
+        if sort is not None:
+            params['sort'] = sort
+
+        return do_paginate(url, params)
 
     def create_group(self, group):
         """

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -830,7 +830,7 @@ class DSpaceClient:
         @return: Iterator of Community
         """
         if top:
-            url = f'{url}/core/communities/search/top'
+            url = f'{self.API_ENDPOINT}/core/communities/search/top'
         else:
             url = f'{self.API_ENDPOINT}/core/communities'
 

--- a/example.py
+++ b/example.py
@@ -9,17 +9,19 @@ some resources in a DSpace 7 repository.
 
 from dspace_rest_client.client import DSpaceClient
 from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
+import os
 
-# Example variables needed for authentication and basic API requests
-# SET THESE TO MATCH YOUR TEST SYSTEM BEFORE RUNNING THE EXAMPLE SCRIPT
-# You can also leave them out of the constructor and set environment variables instead:
-# DSPACE_API_ENDPOINT=
-# DSPACE_API_USERNAME=
-# DSPACE_API_PASSWORD=
-# USER_AGENT=
+# The DSpace client will look for the same environment variables but we can also look for them here explicitly
+# and as an example
 url = 'http://localhost:8080/server/api'
+if 'DSPACE_API_ENDPOINT' in os.environ:
+    url = os.environ['DSPACE_API_ENDPOINT']
 username = 'username@test.system.edu'
+if 'DSPACE_API_USERNAME' in os.environ:
+    username = os.environ['DSPACE_API_USERNAME']
 password = 'password'
+if 'DSPACE_API_PASSWORD' in os.environ:
+    password = os.environ['DSPACE_API_PASSWORD']
 
 # Instantiate DSpace client
 # Note the 'fake_user_agent' setting here -- this will set a string like the following, to get by Cloudfront:
@@ -221,3 +223,8 @@ for top_community in top_communities:
                     # print, or write to file, etc. You want to use the 'content' property of the response object
                     #
                     # print(r.content)
+
+# Finally, let's show the new _iter methods which will transparently handle pagination and return iterators
+# which you can use as normal
+for i, search_result in enumerate(d.search_objects_iter('*:*')):
+    print(f'Result #{i}: {search_result.name} ({search_result.uuid})')


### PR DESCRIPTION
See #25.

Some points to resolve before merging:

- [x] I haven’t implemented the `top` argument to the `get_communities_iter` method yet
- [x] The structure of these methods is all the same: to be DRYly correct I should abstract them over a higher-order function I guess
- [x] Need to double-check which arguments are mandatory and which are optional
- [x] I haven’t added a `get_users_iter` (seems not very useful – `get_users` isn’t even documented). Should I add one anyway?
- [x] Double check test all these methods in a few different cases

~~I also haven’t added `search_objects_iter` because the result for a search doesn’t seem to include `next` links.~~