### PR TITLE
Maintain version centrally, fix non-compliant User-Agent default value

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -7,12 +7,9 @@ These notes are for maintenance of the Git / PyPI source and releases / versions
 All the tasks we need to do, in order, when releasing a new version:
 
 1. **Check the main branch!** - we should have all the changes we want to include merged/picked and tested
-2. **Update setup.py** - this might include other dependency or project description changes, but usually will just be a case of incrementing the version number, e.g. `0.1.9` -> `0.1.10`. Note the new number.
-3. **Update publish.sh** - this simple publish script performs the publish to PyPI and will need the new version number
-4. **Update CHANGELOG.md** - new versions go at the top of the file. See previous release blocks for formatting. I include a 'thanks' or 'reported by' attribution for PRs contributed or issues reported. The new version number from `setup.py` is used for the heading and the (future) PyPI URL
+2. **Update version number** - edit `dspace_rest_client/__init__.py` and update the version. Usually, this will just be a case of incrementing the version number, e.g. `0.1.9` -> `0.1.10`.
+3. **Update CHANGELOG.md** - new versions go at the top of the file. See previous release blocks for formatting. I include a 'thanks' or 'reported by' attribution for PRs contributed or issues reported. The new version number is used for the heading and the (future) PyPI URL
 4. **Commit release preparation** - once you are happy with the steps above, commit with a message like 'Prepare release 0.1.10'
 5. **Push branch** - making sure github is up to date, (in future: CI)
 6. **Clear out build and dist directories**: OPTIONAL, but nice to start with a clean Python build environment before making this new version
-7. **Run publish script** - this will run `setup.py` to build a new version then upload to PyPI with twine - you will need an API token and publish access in PyPI to do this.
-
-TODO: If we just keep a `version` file around or base builds on a version number extracted from tag name, some of these steps can be more easily automated or derived instead of updated by hand, but for now it's all pretty simple.
+7. **Run publish script** - with version number as an argument, e.g. `./publish.sh 0.1.10`. This will run `setup.py` to build a new version then upload to PyPI with twine - you will need an API token and publish access in PyPI to do this.

--- a/console.py
+++ b/console.py
@@ -1,10 +1,10 @@
 from dspace_rest_client.client import DSpaceClient
-from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
+# Import models as needed
+#from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
 import code
-import logging
 import os
 
-# The DSpace client will look for the same environment variables but we can also look for them here explicitly
+# The DSpace client will look for the same environment variables, but we can also look for them here explicitly
 # and as an example
 url = 'http://localhost:8080/server/api'
 if 'DSPACE_API_ENDPOINT' in os.environ:

--- a/dspace_rest_client/__init__.py
+++ b/dspace_rest_client/__init__.py
@@ -1,1 +1,2 @@
 from . import *
+__version__ = '0.1.12'

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -23,6 +23,7 @@ import pysolr
 import os
 from uuid import UUID
 from .models import *
+from . import __version__
 
 __all__ = ['DSpaceClient']
 
@@ -56,7 +57,7 @@ class DSpaceClient:
     API_ENDPOINT = 'http://localhost:8080/server/api'
     SOLR_ENDPOINT = 'http://localhost:8983/solr'
     SOLR_AUTH = None
-    USER_AGENT = 'DSpace Python REST Client'
+    USER_AGENT = f'DSpace-Python-REST-Client/{__version__}'
     if 'DSPACE_API_ENDPOINT' in os.environ:
         API_ENDPOINT = os.environ['DSPACE_API_ENDPOINT']
     LOGIN_URL = f'{API_ENDPOINT}/authn/login'

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -9,14 +9,7 @@ when creating, updating, retrieving and deleting DSpace Objects.
 
 @author Kim Shepherd <kim@shepherd.nz>
 """
-import code
 import json
-import logging
-
-import requests
-from requests import Request
-import os
-from uuid import UUID
 
 __all__ = ['DSpaceObject', 'HALResource', 'ExternalDataObject', 'SimpleDSpaceObject', 'Community',
            'Collection', 'Item', 'Bundle', 'Bitstream', 'User', 'Group']

--- a/example.py
+++ b/example.py
@@ -24,7 +24,7 @@ password = 'password'
 # Instantiate DSpace client
 # Note the 'fake_user_agent' setting here -- this will set a string like the following, to get by Cloudfront:
 # Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36
-# The default is to *not* fake the user agent, and instead use the default of DSpace Python REST Client.
+# The default is to *not* fake the user agent, and instead use the default of DSpace-Python-REST-Client/x.y.z
 # To specify a custom user agent, set the USER_AGENT env variable and leave/set fake_user_agent as False
 d = DSpaceClient(api_endpoint=url, username=username, password=password, fake_user_agent=True)
 

--- a/example_gets.py
+++ b/example_gets.py
@@ -7,7 +7,8 @@ Example Python 3 application using the dspace.py API client library to retrieve 
 """
 
 from dspace_rest_client.client import DSpaceClient
-from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
+# Import models as below if needed
+#from dspace_rest_client.models import Community, Collection, Item, Bundle, Bitstream
 
 # Example variables needed for authentication and basic API requests
 # SET THESE TO MATCH YOUR TEST SYSTEM BEFORE RUNNING THE EXAMPLE SCRIPT
@@ -23,7 +24,7 @@ password = 'password'
 # Instantiate DSpace client
 # Note the 'fake_user_agent' setting here -- this will set a string like the following, to get by Cloudfront:
 # Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36
-# The default is to *not* fake the user agent, and instead use the default of DSpace Python REST Client.
+# The default is to *not* fake the user agent, and instead use the default of DSpace-Python-REST-Client/x.y.z.
 # To specify a custom user agent, set the USER_AGENT env variable and leave/set fake_user_agent as False
 d = DSpaceClient(api_endpoint=url, username=username, password=password, fake_user_agent=True)
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,3 +1,24 @@
 #!/bin/bash
-python setup.py bdist_wheel
-twine upload --repository dspace-rest-client dist/dspace_rest_client-0.1.12-py3-none-any.whl
+
+version=$1
+
+if ! [[ $version =~ ^[0-9]+\.+[0-9]+\.[0-9]+$ ]]; then
+  echo "Usage: publish.sh <version>"
+  echo "Version must match the form x.y.z where all parts are numbers e.g. 0.1.13"
+  exit 1
+fi
+
+echo "Building dspace_rest_client version ${version}"
+if ! python setup.py bdist_wheel; then
+  echo "Error: Failed to build the package"
+  exit 1
+fi
+
+echo "Uploading dspace_rest_client version ${version}"
+if ! twine upload --repository dspace-rest-client dist/dspace_rest_client-0.1.13-py3-none-any.whl; then
+  echo "Error: Failed to upload to PyPI"
+  exit 1
+fi
+
+echo "...done"
+exit 0

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 import setuptools
+from dspace_rest_client import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="dspace-rest-client",
-    version="0.1.12",
+    version=__version__,
     author="Kim Shepherd",
     author_email="kim@the-library-code.de",
     description="A DSpace 7 REST API client library",


### PR DESCRIPTION
Fixes #26 

Default user agent value is now e.g. `DSpace-Python-REST-Client/0.1.12`

Also tidies up some imports and improves version number management:

* Maintain `__version__` in `__init__.py` and import it in client and setup.py
* Update publish script to accept version from CLI arg
* Update maintenance doc