### PR TITLE
Extend search_objects to allow configuration parameter

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -487,6 +487,7 @@ class DSpaceClient:
         size=20,
         sort=None,
         dso_type=None,
+        configuration='default',
         embeds=None,
     ):
         """
@@ -498,6 +499,7 @@ class DSpaceClient:
         @param size: size of page (aka. 'rows'), affects the page parameter above
         @param sort: sort eg. 'title,asc'
         @param dso_type: DSO type to further filter results
+        @param configuration: Search (discovery) configuration to apply to the query
         @param embeds:  Optional list of embeds to apply to each search object result
         @return:        list of DspaceObject objects constructed from API resources
         """
@@ -518,6 +520,8 @@ class DSpaceClient:
             params["page"] = page
         if sort is not None:
             params["sort"] = sort
+        if configuration is not None:
+            params['configuration'] = configuration
 
         r_json = self.fetch_resource(url=url, params={**params, **filters})
 
@@ -548,6 +552,7 @@ class DSpaceClient:
         filters=None,
         dso_type=None,
         sort=None,
+        configuration='default',
         embeds=None,
     ):
         """
@@ -557,6 +562,7 @@ class DSpaceClient:
         @param filters: discovery filters as dict eg. {'f.entityType': 'Publication,equals', ... }
         @param sort: sort eg. 'title,asc'
         @param dso_type: DSO type to further filter results
+        @param configuration: Search (discovery) configuration to apply to the query
         @param embeds:  Optional list of embeds to apply to each search object result
         @return:        Iterator of SimpleDSpaceObject
         """
@@ -572,6 +578,8 @@ class DSpaceClient:
             params["dsoType"] = dso_type
         if sort is not None:
             params["sort"] = sort
+        if configuration is not None:
+            params['configuration'] = configuration
 
         return do_paginate(url, {**params, **filters})
 

--- a/example.py
+++ b/example.py
@@ -220,7 +220,7 @@ for top_community in top_communities:
         # scoped to this collection
         # (there is no collection/items endpoint, though there is a /mappedItems endpoint,
         # not yet implemented here)
-        items = d.search_objects(query='*:*', scope=collection.uuid, dso_type='item')
+        items = d.search_objects(query='*:*', scope=collection.uuid, dso_type='item', configuration='default')
         for item in items:
             print(f'{item.name} ({item.uuid})')
             # Get all bundles in this item

--- a/example.py
+++ b/example.py
@@ -40,6 +40,12 @@ if not authenticated:
     print('Error logging in! Giving up.')
     sys.exit(1)
 
+# An example of searching for workflow items (any search configuration from discovery.xml can be used)
+# note that the results here depend on the workflow role / access of the logged in user
+search_results = d.search_objects(query='*:*', dso_type='item', configuration='workflow')
+for result in search_results:
+    print(f'{result.name} ({result.uuid})')
+
 # Put together some basic Community data.
 # See https://github.com/DSpace/RestContract/blob/main/communities.md
 community_data = {


### PR DESCRIPTION
Accept a `configuration` parameter to the `search_objects` client method so non-default searches can be performed.
Configurations are defined in the backend, in `discovery.xml`.
Note that some configurations like workflow and workspace will return different results depending on which user is authenticated.