### PR TITLE
Various tidy-up changes to Models, Decorators and JSON parse error handling

### DIFF
--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -121,6 +121,7 @@ class DSpaceClient:
         REPLACE = "replace"
         MOVE = "move"
 
+    @staticmethod
     def paginated(embed_name, item_constructor, embedding=lambda x: x):
         """
         @param embed_name: The key under '_embedded' in the JSON response that contains the
@@ -151,7 +152,7 @@ class DSpaceClient:
                         else:
                             url = None
 
-                return fun(do_paginate, self, *args, **kwargs)
+                return fun(self, do_paginate, *args, **kwargs)
 
             return decorated
         return decorator
@@ -523,8 +524,8 @@ class DSpaceClient:
         embedding=lambda x: x["_embedded"]["searchResult"],
     )
     def search_objects_iter(
-        do_paginate,
         self,
+        do_paginate,
         query=None,
         scope=None,
         filters=None,
@@ -751,7 +752,7 @@ class DSpaceClient:
         return bundles
 
     @paginated("bundles", Bundle)
-    def get_bundles_iter(do_paginate, self, parent, sort=None, embeds=None):
+    def get_bundles_iter(self, do_paginate, parent, sort=None, embeds=None):
         """
         Get bundles for an item, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param parent:  python Item object, from which the UUID will be referenced in the URL.
@@ -836,7 +837,7 @@ class DSpaceClient:
                 return bitstreams
 
     @paginated("bitstreams", Bitstream)
-    def get_bitstreams_iter(do_paginate, self, bundle, sort=None, embeds=None):
+    def get_bitstreams_iter(self, do_paginate, bundle, sort=None, embeds=None):
         """
         Get all bitstreams for a specific bundle, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param bundle:  A python Bundle object to parse for bitstream links to retrieve
@@ -900,7 +901,7 @@ class DSpaceClient:
         url = f"{self.API_ENDPOINT}/core/bundles/{bundle.uuid}/bitstreams"
 
         try:
-            with smart_open.open(path, "rb") as file_obj:
+            with smart_open.open(path, "rb") as file_obj:  # type: ignore[attr-defined]
                 file = (name, file_obj.read(), mime)
             files = {"file": file}
             properties = {"name": name, "metadata": metadata, "bundleName": bundle.name}
@@ -1017,7 +1018,7 @@ class DSpaceClient:
         return communities
 
     @paginated("communities", Community)
-    def get_communities_iter(do_paginate, self, sort=None, top=False, embeds=None):
+    def get_communities_iter(self, do_paginate, sort=None, top=False, embeds=None):
         """
         Get communities as an iterator, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param top:     whether to restrict search to top communities (default: false)
@@ -1108,7 +1109,7 @@ class DSpaceClient:
         return collections
 
     @paginated("collections", Collection)
-    def get_collections_iter(do_paginate, self, community=None, sort=None, embeds=None):
+    def get_collections_iter(self, do_paginate, community=None, sort=None, embeds=None):
         """
         Get collections as an iterator, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param community:   Community object. If present, collections for a community
@@ -1368,7 +1369,7 @@ class DSpaceClient:
         return users
 
     @paginated("epersons", User)
-    def get_users_iter(do_paginate, self, sort=None, embeds=None):
+    def get_users_iter(self, do_paginate, sort=None, embeds=None):
         """
         Get an iterator of users (epersons) in the DSpace instance, automatically handling pagination by requesting the next page when all items from one page have been consumed
         @param sort:     Optional sort parameter
@@ -1383,7 +1384,7 @@ class DSpaceClient:
         return do_paginate(url, params)
 
     @paginated("groups", Group)
-    def search_groups_by_metadata_iter(do_paginate, self, query, embeds=None):
+    def search_groups_by_metadata_iter(self, do_paginate, query, embeds=None):
         """
         Search for groups by metadata
         @param query: Search query (UUID or group name)
@@ -1501,7 +1502,7 @@ class DSpaceClient:
                 logging.error(f"Error resolving identifier {identifier} to DSO: {r.status_code}")
 
     @paginated("resourcepolicies", ResourcePolicy)
-    def get_resource_policies_iter(do_paginate, self, parent=None, action=None, embeds=None):
+    def get_resource_policies_iter(self, do_paginate, parent=None, action=None, embeds=None):
         """
         Get resource policies (as an iterator) for a given parent object and action
         @param parent: UUID of an object to which the policy applies

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -92,7 +92,6 @@ class DSpaceClient:
     """
 
     # Set up basic environment, variables
-    session = None
     API_ENDPOINT = "http://localhost:8080/server/api"
     SOLR_ENDPOINT = "http://localhost:8983/solr"
     SOLR_AUTH = None
@@ -112,7 +111,6 @@ class DSpaceClient:
         SOLR_AUTH = os.environ["SOLR_AUTH"]
     if "USER_AGENT" in os.environ:
         USER_AGENT = os.environ["USER_AGENT"]
-    verbose = False
     ITER_PAGE_SIZE = 20
     PROXY_DICT = dict(http=os.environ["PROXY_URL"],https=os.environ["PROXY_URL"]) if "PROXY_URL" in os.environ else dict()
 
@@ -284,7 +282,7 @@ class DSpaceClient:
         # Update headers with new bearer token if present
         if "Authorization" in r.headers:
             self.session.headers.update(
-                {"Authorization": r.headers.get("Authorization")}
+                {"Authorization": r.headers["Authorization"]}
             )
 
         # Get and check authentication status
@@ -294,7 +292,7 @@ class DSpaceClient:
         )
         if r.status_code == 200:
             r_json = parse_json(r)
-            if "authenticated" in r_json and r_json["authenticated"] is True:
+            if r_json is not None and "authenticated" in r_json and r_json["authenticated"] is True:
                 logging.info("Authenticated successfully as %s", self.USERNAME)
                 return r_json["authenticated"]
 
@@ -503,6 +501,8 @@ class DSpaceClient:
 
         r_json = self.fetch_resource(url=url, params={**params, **filters})
 
+        if r_json is None:
+            return dsos
         # instead lots of 'does this key exist, etc etc' checks, just go for it and wrap in a try?
         try:
             results = r_json["_embedded"]["searchResult"]["_embedded"]["objects"]
@@ -611,8 +611,10 @@ class DSpaceClient:
         if r.status_code == 201:
             # 201 Created - success!
             new_dso = parse_json(r)
+            if new_dso is None:
+                return r
             logging.info(
-                "%s %s created successfully!", new_dso["type"], new_dso["uuid"]
+                "%s %s created successfully!", new_dso.get("type"), new_dso.get("uuid")
             )
         else:
             logging.error(
@@ -702,7 +704,7 @@ class DSpaceClient:
                 )
                 return None
         except ValueError as e:
-            logging.error("Error deleting DSO %s: %s", dso.uuid, e)
+            logging.error("Error deleting DSO %s: %s", url, e)
             return None
 
     # PAGINATION
@@ -739,7 +741,7 @@ class DSpaceClient:
         try:
             if single_result:
                 bundles.append(Bundle(r_json))
-            if not single_result:
+            if not single_result and r_json is not None:
                 resources = r_json["_embedded"]["bundles"]
                 for resource in resources:
                     bundles.append(Bundle(resource))
@@ -825,7 +827,7 @@ class DSpaceClient:
             params["sort"] = sort
 
         r_json = self.fetch_resource(url, params=params)
-        if "_embedded" in r_json:
+        if r_json is not None and "_embedded" in r_json:
             if "bitstreams" in r_json["_embedded"]:
                 bitstreams = []
                 for bitstream_resource in r_json["_embedded"]["bitstreams"]:
@@ -891,6 +893,10 @@ class DSpaceClient:
         # TODO: Better error detection and handling for file reading
         if metadata is None:
             metadata = {}
+        if bundle is None:
+            logging.error("Cannot create bitstream without bundle")
+            return None
+
         url = f"{self.API_ENDPOINT}/core/bundles/{bundle.uuid}/bitstreams"
 
         try:
@@ -923,7 +929,7 @@ class DSpaceClient:
         # we should enhance self.api_post to be able to send files and use our decorators
         if r.status_code == 403:
             r_json = parse_json(r)
-            if "message" in r_json and "CSRF token" in r_json["message"]:
+            if r_json is not None and "message" in r_json and "CSRF token" in r_json["message"]:
                 if retry:
                     logging.error("Already retried... something must be wrong")
                 else:
@@ -1000,11 +1006,11 @@ class DSpaceClient:
         r_json = self.fetch_resource(url, params)
         # Empty list
         communities = []
-        if "_embedded" in r_json:
+        if r_json is not None and "_embedded" in r_json:
             if "communities" in r_json["_embedded"]:
                 for community_resource in r_json["_embedded"]["communities"]:
                     communities.append(Community(community_resource))
-        elif "uuid" in r_json:
+        elif r_json is not None and "uuid" in r_json:
             # This is a single communities
             communities.append(Community(r_json))
         # Return list (populated or empty)
@@ -1089,12 +1095,12 @@ class DSpaceClient:
         r_json = self.fetch_resource(url, params=params)
         # Empty list
         collections = []
-        if "_embedded" in r_json:
+        if r_json is not None and "_embedded" in r_json:
             # This is a list of collections
             if "collections" in r_json["_embedded"]:
                 for collection_resource in r_json["_embedded"]["collections"]:
                     collections.append(Collection(collection_resource))
-        elif "uuid" in r_json:
+        elif r_json is not None and "uuid" in r_json:
             # This is a single collection
             collections.append(Collection(r_json))
 
@@ -1167,12 +1173,12 @@ class DSpaceClient:
         r_json = self.fetch_resource(url, params=parse_params(embeds=embeds))
         # Empty list
         items = []
-        if "_embedded" in r_json:
+        if r_json is not None and "_embedded" in r_json:
             # This is a list of items
             if "items" in r_json["_embedded"]:
                 for item_resource in r_json["_embedded"]["items"]:
                     items.append(Item(item_resource))
-        elif "uuid" in r_json:
+        elif r_json is not None and "uuid" in r_json:
             # This is a single item
             items.append(Item(r_json))
 
@@ -1355,7 +1361,7 @@ class DSpaceClient:
             params["sort"] = sort
         r = self.api_get(url, params=params)
         r_json = parse_json(response=r)
-        if "_embedded" in r_json:
+        if r_json is not None and "_embedded" in r_json:
             if "epersons" in r_json["_embedded"]:
                 for user_resource in r_json["_embedded"]["epersons"]:
                     users.append(User(user_resource))
@@ -1544,6 +1550,9 @@ class DSpaceClient:
         if r.status_code == 200 or r.status_code == 201:
             # 200 OK or 201 Created means Created - success! (201 is used now, 200 perhaps in teh past?)
             new_policy = parse_json(r)
+            if new_policy is None:
+                logging.error("Response containing new resource policy is empty or invalid")
+                return None
             logging.info("%s %s created successfully!",
                          new_policy["type"], new_policy["id"])
             return ResourcePolicy(api_resource=new_policy)

--- a/dspace_rest_client/client.py
+++ b/dspace_rest_client/client.py
@@ -26,6 +26,7 @@ import requests
 from requests import Request
 import pysolr
 import smart_open
+from typing import cast, IO
 
 from .models import (
     SimpleDSpaceObject,
@@ -901,7 +902,7 @@ class DSpaceClient:
         url = f"{self.API_ENDPOINT}/core/bundles/{bundle.uuid}/bitstreams"
 
         try:
-            with smart_open.open(path, "rb") as file_obj:  # type: ignore[attr-defined]
+            with cast(IO[bytes], smart_open.open(path, "rb")) as file_obj:
                 file = (name, file_obj.read(), mime)
             files = {"file": file}
             properties = {"name": name, "metadata": metadata, "bundleName": bundle.name}

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -19,45 +19,38 @@ class HALResource:
     """
     Base class to represent HAL+JSON API resources
     """
-    links = {}
-    type = None
-    embedded = dict()
 
     def __init__(self, api_resource=None):
         """
         Default constructor
         @param api_resource: optional API resource (JSON) from a GET response or successful POST can populate instance
         """
+        self.links = {}
+        self.embedded = {} 
+        self.type = None
+
         if api_resource is not None:
-            if 'type' in api_resource:
-                self.type = api_resource['type']
-            if '_links' in api_resource:
-                self.links = api_resource['_links'].copy()
-            if '_embedded' in api_resource:
-                self.embedded = api_resource['_embedded'].copy()
-            else:
-                self.links = {'self': {'href': None}}
+            self.links = api_resource.get('_links', {}).copy()
+            self.embedded = api_resource.get('_embedded', {}).copy()
+            self.type = api_resource.get('type')
+        else:
+            self.links = {'self': {'href': None}}
 
 class AddressableHALResource(HALResource):
-    id = None
     def __init__(self, api_resource=None):
         super().__init__(api_resource)
+        self.id = None
+
         if api_resource is not None:
-            if 'id' in api_resource:
-                self.id = api_resource['id']
+            self.id = api_resource.get('id')
 
     def as_dict(self):
         return {'id': self.id}
 
-class ExternalDataObject(HALResource):
+class ExternalDataObject(AddressableHALResource):
     """
     Generic External Data Object as configured in DSpace's external data providers framework
     """
-    id = None
-    display = None
-    value = None
-    externalSource = None
-    metadata = {}
 
     def __init__(self, api_resource=None):
         """
@@ -65,20 +58,16 @@ class ExternalDataObject(HALResource):
         @param api_resource: optional API resource (JSON) from a GET response or successful POST can populate instance
         """
         super().__init__(api_resource)
-
+        self.display = None
+        self.value = None
+        self.externalSource = None
         self.metadata = {}
 
         if api_resource is not None:
-            if 'id' in api_resource:
-                self.id = api_resource['id']
-            if 'display' in api_resource:
-                self.display = api_resource['display']
-            if 'value' in api_resource:
-                self.value = api_resource['value']
-            if 'externalSource' in api_resource:
-                self.externalSource = api_resource['externalSource']
-            if 'metadata' in api_resource:
-                self.metadata = api_resource['metadata'].copy()
+            self.display = api_resource.get('display')
+            self.value = api_resource.get('value')
+            self.externalSource = api_resource.get('externalSource')
+            self.metadata = api_resource.get('metadata').copy()
 
     def get_metadata_values(self, field):
         """
@@ -86,10 +75,7 @@ class ExternalDataObject(HALResource):
         @param field: DSpace field, eg. dc.creator
         @return: list of strings
         """
-        values = []
-        if field in self.metadata:
-            values = self.metadata[field]
-        return values
+        return self.metadata.get(field, [])
 
 
 class DSpaceObject(HALResource):
@@ -99,13 +85,6 @@ class DSpaceObject(HALResource):
     operations are included in the dict returned by asDict(). Implements toJSON() as well.
     This class can be used on its own but is generally expected to be extended by other types: Item, Bitstream, etc.
     """
-    uuid = None
-    name = None
-    handle = None
-    metadata = {}
-    lastModified = None
-    type = None
-    parent = None
 
     def __init__(self, api_resource=None, dso=None):
         """
@@ -113,31 +92,29 @@ class DSpaceObject(HALResource):
         @param api_resource: optional API resource (JSON) from a GET response or successful POST can populate instance
         """
         super().__init__(api_resource)
+        self.uuid = None
+        self.name = None
+        self.handle = None
+        self.lastModified = None
+        self.parent = None
         self.type = None
         self.metadata = {}
 
         if dso is not None:
             api_resource = dso.as_dict()
             self.links = dso.links.copy()
+
         if api_resource is not None:
-            if 'id' in api_resource:
-                self.id = api_resource['id']
-            if 'uuid' in api_resource:
-                self.uuid = api_resource['uuid']
-            if 'type' in api_resource:
-                self.type = api_resource['type']
-            if 'name' in api_resource:
-                self.name = api_resource['name']
-            if 'handle' in api_resource:
-                self.handle = api_resource['handle']
-            if 'metadata' in api_resource:
-                self.metadata = api_resource['metadata'].copy()
-            if 'lastModified' in api_resource:
-                self.lastModified = api_resource['lastModified']
+            self.id = api_resource.get('id')
+            self.uuid = api_resource.get('uuid')
+            self.type = api_resource.get('type')
+            self.name = api_resource.get('name')
+            self.handle = api_resource.get('handle')
+            self.metadata = api_resource.get('metadata', {}).copy()
+            self.lastModified = api_resource.get('lastModified')
             # Python interprets _ prefix as private so for now, renaming this and handling it separately
             # alternatively - each item could implement getters, or a public method to return links
-            if '_links' in api_resource:
-                self.links = api_resource['_links'].copy()
+            self.links = api_resource.get('_links', {}).copy()
 
     def add_metadata(self, field, value, language=None, authority=None, confidence=-1, place=None):
         """
@@ -155,17 +132,14 @@ class DSpaceObject(HALResource):
         """
         if field is None or value is None:
             return
-        if field in self.metadata:
-            values = self.metadata[field]
-            # Ensure we don't accidentally duplicate place value. If this place already exists, the user
-            # should use a patch operation or we should allow another way to re-order / re-calc place?
-            # For now, we'll just set place to none if it matches an existing place
-            for v in values:
-                if v['place'] == place:
-                    place = None
-                    break
-        else:
-            values = []
+        values = self.metadata.get(field, [])
+        # Ensure we don't accidentally duplicate place value. If this place already exists, the user
+        # should use a patch operation or we should allow another way to re-order / re-calc place?
+        # For now, we'll just set place to none if it matches an existing place
+        for v in values:
+            if v['place'] == place:
+                place = None
+                break
         values.append({"value": value, "language": language,
                        "authority": authority, "confidence": confidence, "place": place})
         self.metadata[field] = values
@@ -218,17 +192,17 @@ class Item(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for items
     """
-    type = 'item'
-    inArchive = False
-    discoverable = False
-    withdrawn = False
-    metadata = {}
 
     def __init__(self, api_resource=None, dso=None):
         """
         Default constructor. Call DSpaceObject init then set item-specific attributes
         @param api_resource: API result object to use as initial data
         """
+        self.type = 'item'
+        self.inArchive = False
+        self.discoverable = False
+        self.withdrawn = False
+        self.metadata = {}
         if dso is not None:
             api_resource = dso.as_dict()
             super().__init__(dso=dso)
@@ -237,9 +211,9 @@ class Item(SimpleDSpaceObject):
 
         if api_resource is not None:
             self.type = 'item'
-            self.inArchive = api_resource['inArchive'] if 'inArchive' in api_resource else True
-            self.discoverable = api_resource['discoverable'] if 'discoverable' in api_resource else False
-            self.withdrawn = api_resource['withdrawn'] if 'withdrawn' in api_resource else False
+            self.inArchive = api_resource.get('inArchive', True)
+            self.discoverable = api_resource.get('discoverable', False)
+            self.withdrawn = api_resource.get('withdrawn', False)
 
     def get_metadata_values(self, field):
         """
@@ -247,10 +221,7 @@ class Item(SimpleDSpaceObject):
         @param field: DSpace field, eg. dc.creator
         @return: list of strings
         """
-        values = []
-        if field in self.metadata:
-            values = self.metadata[field]
-        return values
+        return self.metadata.get(field, [])
 
     def as_dict(self):
         """
@@ -274,7 +245,6 @@ class Community(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for communities
     """
-    type = 'community'
 
     def __init__(self, api_resource=None):
         """
@@ -299,7 +269,6 @@ class Collection(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for collections
     """
-    type = 'collection'
 
     def __init__(self, api_resource=None):
         """
@@ -323,7 +292,6 @@ class Bundle(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for bundles
     """
-    type = 'bundle'
 
     def __init__(self, api_resource=None):
         """
@@ -347,15 +315,6 @@ class Bitstream(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for bundles
     """
-    type = 'bitstream'
-    # Bitstream has a few extra fields specific to file storage
-    bundleName = None
-    sizeBytes = None
-    checkSum = {
-        'checkSumAlgorithm': 'MD5',
-        'value': None
-    }
-    sequenceId = None
 
     def __init__(self, api_resource=None):
         """
@@ -364,14 +323,20 @@ class Bitstream(DSpaceObject):
         """
         super().__init__(api_resource)
         self.type = 'bitstream'
-        if 'bundleName' in api_resource:
-            self.bundleName = api_resource['bundleName']
-        if 'sizeBytes' in api_resource:
-            self.sizeBytes = api_resource['sizeBytes']
-        if 'checkSum' in api_resource:
-            self.checkSum = api_resource['checkSum']
-        if 'sequenceId' in api_resource:
-            self.sequenceId = api_resource['sequenceId']
+        # Bitstream has a few extra fields specific to file storage
+        self.bundleName = None
+        self.sizeBytes = None
+        self.checkSum = {
+            'checkSumAlgorithm': 'MD5',
+            'value': None
+        }
+        self.sequenceId = None
+
+        if api_resource is not None:
+            self.bundleName = api_resource.get('bundleName')
+            self.sizeBytes = api_resource.get('sizeBytes')
+            self.checkSum = api_resource.get('checkSum', self.checkSum)
+            self.sequenceId = api_resource.get('sequenceId')
 
     def as_dict(self):
         """
@@ -399,28 +364,24 @@ class BitstreamFormat(AddressableHALResource):
           "type": "bitstreamformat"
         }
     """
-    shortDescription = None
-    description = None
-    mimetype = None
-    supportLevel = None
-    internal = False
-    extensions = []
-    type = 'bitstreamformat'
 
     def __init__(self, api_resource):
         super(BitstreamFormat, self).__init__(api_resource)
-        if 'shortDescription' in api_resource:
-            self.shortDescription = api_resource['shortDescription']
-        if 'description' in api_resource:
-            self.description = api_resource['description']
-        if 'mimetype' in api_resource:
-            self.mimetype = api_resource['mimetype']
-        if 'supportLevel' in api_resource:
-            self.supportLevel = api_resource['supportLevel']
-        if 'internal' in api_resource:
-            self.internal = api_resource['internal']
-        if 'extensions' in api_resource:
-            self.extensions = api_resource['extensions'].copy()
+        self.shortDescription = None
+        self.description = None
+        self.mimetype = None
+        self.supportLevel = None
+        self.internal = False
+        self.extensions = []
+        self.type = 'bitstreamformat'
+
+        if api_resource is not None:
+            self.shortDescription = api_resource.get('shortDescription')
+            self.description = api_resource.get('description')
+            self.mimetype = api_resource.get('mimetype')
+            self.supportLevel = api_resource.get('supportLevel')
+            self.internal = api_resource.get('internal')
+            self.extensions = api_resource.get('extensions', {}).copy()
 
     def as_dict(self):
         parent_dict = super(BitstreamFormat, self).as_dict()
@@ -439,9 +400,6 @@ class Group(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and methods for groups (aka. EPersonGroups)
     """
-    type = 'group'
-    name = None
-    permanent = False
 
     def __init__(self, api_resource=None):
         """
@@ -449,11 +407,13 @@ class Group(DSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
+        self.name = None
+        self.permanent = False
         self.type = 'group'
-        if 'name' in api_resource:
-            self.name = api_resource['name']
-        if 'permanent' in api_resource:
-            self.permanent = api_resource['permanent']
+
+        if api_resource is not None:
+            self.name = api_resource.get('name')
+            self.permanent = api_resource.get('permanent')
 
     def as_dict(self):
         """
@@ -469,14 +429,6 @@ class User(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and methods for users (aka. EPersons)
     """
-    type = 'user'
-    name = None
-    netid = None
-    lastActive = None
-    canLogIn = False
-    email = None
-    requireCertificate = False
-    selfRegistered = False
 
     def __init__(self, api_resource=None):
         """
@@ -484,21 +436,23 @@ class User(SimpleDSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
+        self.name = None
+        self.netid = None
+        self.lastActive = None
+        self.canLogIn = False
+        self.email = None
+        self.requireCertificate = False
+        self.selfRegistered = False
         self.type = 'user'
-        if 'name' in api_resource:
-            self.name = api_resource['name']
-        if 'netid' in api_resource:
-            self.netid = api_resource['netid']
-        if 'lastActive' in api_resource:
-            self.lastActive = api_resource['lastActive']
-        if 'canLogIn' in api_resource:
-            self.canLogIn = api_resource['canLogIn']
-        if 'email' in api_resource:
-            self.email = api_resource['email']
-        if 'requireCertificate' in api_resource:
-            self.requireCertificate = api_resource['requireCertificate']
-        if 'selfRegistered' in api_resource:
-            self.selfRegistered = api_resource['selfRegistered']
+
+        if api_resource is not None:
+            self.name = api_resource.get('name')
+            self.netid = api_resource.get('netid')
+            self.lastActive = api_resource.get('lastActive')
+            self.canLogIn = api_resource.get('canLogIn')
+            self.email = api_resource.get('email')
+            self.requireCertificate = api_resource.get('requireCertificate')
+            self.selfRegistered = api_resource.get('selfRegistered')
 
     def as_dict(self):
         """
@@ -512,21 +466,19 @@ class User(SimpleDSpaceObject):
         return {**dso_dict, **user_dict}
 
 class InProgressSubmission(AddressableHALResource):
-    lastModified = None
-    step = None
-    sections = {}
-    type = None
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
-        if 'lastModified' in api_resource:
-            self.lastModified = api_resource['lastModified']
-        if 'step' in api_resource:
-            self.step = api_resource['lastModified']
-        if 'sections' in api_resource:
-            self.sections = api_resource['sections'].copy()
-        if 'type' in api_resource:
-            self.lastModified = api_resource['lastModified']
+        self.lastModified = None
+        self.step = None
+        self.sections = {}
+        self.type = None
+
+        if api_resource is not None:
+            self.lastModified = api_resource.get('lastModified')
+            self.step = api_resource.get('lastModified')
+            self.sections = api_resource.get('sections', {}).copy()
+            self.lastModified = api_resource.get('lastModified')
 
     def as_dict(self):
         parent_dict = super().as_dict()
@@ -554,10 +506,11 @@ class EntityType(AddressableHALResource):
     """
     def __init__(self, api_resource):
         super().__init__(api_resource)
-        if 'label' in api_resource:
-            self.label = api_resource['label']
-        if 'type' in api_resource:
-            self.label = api_resource['type']
+        self.label = None
+        self.type = 'entitytype' 
+
+        if api_resource is not None:
+            self.label = api_resource.get('label')
 
 class RelationshipType(AddressableHALResource):
     """
@@ -617,24 +570,22 @@ class SearchResult(HALResource):
           }
         }, "facets"... (TODO)
     """
-    query = None
-    scope = None
-    appliedFilters = [] 
-    type = None
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
-        if 'lastModified' in api_resource:
-            self.lastModified = api_resource['lastModified']
-        if 'step' in api_resource:
-            self.step = api_resource['step']
-        if 'sections' in api_resource:
-            self.sections = api_resource['sections'].copy()
-        if 'type' in api_resource and self.type is not None:
-            self.type = api_resource['type']
+        self.query = None
+        self.scope = None
+        self.appliedFilters = [] 
+        self.type = None
+
+        if api_resource is not None:
+            self.lastModified = api_resource.get('lastModified')
+            self.step = api_resource.get('step')
+            self.sections = api_resource.get('sections', {}).copy()
+            self.type = api_resource.get('type')
 
     def as_dict(self):
-        parent_dict = super().as_dict()
+        parent_dict = super().__dict__
         dict = {
             'lastModified': self.lastModified,
             'step': self.step,
@@ -648,28 +599,24 @@ class ResourcePolicy(AddressableHALResource):
     A resource policy to control access and authorization to DSpace objects
     See: https://github.com/DSpace/RestContract/blob/main/resourcepolicies.md
     """
-    type = 'resourcepolicy'
-    name = None
-    description = None
-    policyType = None
-    action = None
-    startDate = None
-    endDate = None
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
-        if 'name' in api_resource:
-            self.name = api_resource['name']
-        if 'description' in api_resource:
-            self.description = api_resource['description']
-        if 'policyType' in api_resource:
-            self.policyType = api_resource['policyType']
-        if 'action' in api_resource:
-            self.action = api_resource['action']
-        if 'startDate' in api_resource:
-            self.startDate = api_resource['startDate']
-        if 'endDate' in api_resource:
-            self.endDate = api_resource['endDate']
+        self.type = 'resourcepolicy'
+        self.name = None
+        self.description = None
+        self.policyType = None
+        self.action = None
+        self.startDate = None
+        self.endDate = None
+
+        if api_resource is not None:
+            self.name = api_resource.get('name')
+            self.description = api_resource.get('description')
+            self.policyType = api_resource.get('policyType')
+            self.action = api_resource.get('action')
+            self.startDate = api_resource.get('startDate')
+            self.endDate = api_resource.get('endDate')
 
     def as_dict(self):
         hal_dict = super().as_dict()

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -19,6 +19,7 @@ class HALResource:
     """
     Base class to represent HAL+JSON API resources
     """
+    type = None
 
     def __init__(self, api_resource=None):
         """
@@ -27,14 +28,15 @@ class HALResource:
         """
         self.links = {}
         self.embedded = {} 
-        self.type = None
 
         if api_resource is not None:
             self.links = api_resource.get('_links', {}).copy()
             self.embedded = api_resource.get('_embedded', {}).copy()
-            self.type = api_resource.get('type')
         else:
             self.links = {'self': {'href': None}}
+
+    def as_dict(self):
+        return {'type': self.type}
 
 class AddressableHALResource(HALResource):
     def __init__(self, api_resource=None):
@@ -45,12 +47,17 @@ class AddressableHALResource(HALResource):
             self.id = api_resource.get('id')
 
     def as_dict(self):
-        return {'id': self.id}
+        parent_dict = super().as_dict()
+        this_dict = {'id': self.id}
+        return {**parent_dict, **this_dict}
 
 class ExternalDataObject(AddressableHALResource):
     """
     Generic External Data Object as configured in DSpace's external data providers framework
+    TODO: this is also known as externalSourceEntry? Should the class name be modified or aliased?
+    Or should we draw a subtle distinction between the two even if they share the same model
     """
+    type = "externalSourceEntry"
 
     def __init__(self, api_resource=None):
         """
@@ -77,8 +84,17 @@ class ExternalDataObject(AddressableHALResource):
         """
         return self.metadata.get(field, [])
 
+    def as_dict(self):
+        parent_dict = super().as_dict()
+        edo_dict = {
+            'display': self.display,
+            'value': self.value,
+            'externalSource': self.externalSource,
+            'metadata': self.metadata,
+        }
+        return {**parent_dict, **edo_dict}
 
-class DSpaceObject(HALResource):
+class DSpaceObject(AddressableHALResource):
     """
     Base class to represent DSpaceObject API resources
     The variables here are present in an _embedded response and the ones required for POST / PUT / PATCH
@@ -97,7 +113,6 @@ class DSpaceObject(HALResource):
         self.handle = None
         self.lastModified = None
         self.parent = None
-        self.type = None
         self.metadata = {}
 
         if dso is not None:
@@ -107,7 +122,6 @@ class DSpaceObject(HALResource):
         if api_resource is not None:
             self.id = api_resource.get('id')
             self.uuid = api_resource.get('uuid')
-            self.type = api_resource.get('type')
             self.name = api_resource.get('name')
             self.handle = api_resource.get('handle')
             self.metadata = api_resource.get('metadata', {}).copy()
@@ -165,14 +179,15 @@ class DSpaceObject(HALResource):
         Return custom dict of this DSpaceObject with specific attributes included (no _links, etc.)
         @return: dict of this DSpaceObject for API use
         """
-        return {
+        parent_dict = super().as_dict()
+        dso_dict = {
             'uuid': self.uuid,
             'name': self.name,
             'handle': self.handle,
             'metadata': self.metadata,
-            'lastModified': self.lastModified,
-            'type': self.type,
+            'lastModified': self.lastModified
         }
+        return {**parent_dict, **dso_dict}
 
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=None)
@@ -192,13 +207,13 @@ class Item(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for items
     """
+    type = "item"
 
     def __init__(self, api_resource=None, dso=None):
         """
         Default constructor. Call DSpaceObject init then set item-specific attributes
         @param api_resource: API result object to use as initial data
         """
-        self.type = 'item'
         self.inArchive = False
         self.discoverable = False
         self.withdrawn = False
@@ -210,7 +225,6 @@ class Item(SimpleDSpaceObject):
             super().__init__(api_resource)
 
         if api_resource is not None:
-            self.type = 'item'
             self.inArchive = api_resource.get('inArchive', True)
             self.discoverable = api_resource.get('discoverable', False)
             self.withdrawn = api_resource.get('withdrawn', False)
@@ -245,6 +259,7 @@ class Community(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for communities
     """
+    type = 'community'
 
     def __init__(self, api_resource=None):
         """
@@ -252,7 +267,6 @@ class Community(SimpleDSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
-        self.type = 'community'
 
     def as_dict(self):
         """
@@ -269,6 +283,7 @@ class Collection(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for collections
     """
+    type = "collection"
 
     def __init__(self, api_resource=None):
         """
@@ -276,7 +291,6 @@ class Collection(SimpleDSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
-        self.type = 'collection'
 
     def as_dict(self):
         dso_dict = super().as_dict()
@@ -292,6 +306,7 @@ class Bundle(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for bundles
     """
+    type = "collection"
 
     def __init__(self, api_resource=None):
         """
@@ -299,7 +314,6 @@ class Bundle(DSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
-        self.type = 'bundle'
 
     def as_dict(self):
         """
@@ -315,6 +329,7 @@ class Bitstream(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for bundles
     """
+    type = "bitstream"
 
     def __init__(self, api_resource=None):
         """
@@ -322,7 +337,6 @@ class Bitstream(DSpaceObject):
         @param api_resource: API result object to use as initial data
         """
         super().__init__(api_resource)
-        self.type = 'bitstream'
         # Bitstream has a few extra fields specific to file storage
         self.bundleName = None
         self.sizeBytes = None
@@ -364,6 +378,7 @@ class BitstreamFormat(AddressableHALResource):
           "type": "bitstreamformat"
         }
     """
+    type = "bitstreamformat"
 
     def __init__(self, api_resource):
         super(BitstreamFormat, self).__init__(api_resource)
@@ -373,7 +388,6 @@ class BitstreamFormat(AddressableHALResource):
         self.supportLevel = None
         self.internal = False
         self.extensions = []
-        self.type = 'bitstreamformat'
 
         if api_resource is not None:
             self.shortDescription = api_resource.get('shortDescription')
@@ -391,8 +405,7 @@ class BitstreamFormat(AddressableHALResource):
             'mimetype': self.mimetype,
             'supportLevel': self.supportLevel,
             'internal': self.internal,
-            'extensions': self.extensions,
-            'type': self.type
+            'extensions': self.extensions
         }
         return {**parent_dict, **dict}
 
@@ -400,6 +413,7 @@ class Group(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and methods for groups (aka. EPersonGroups)
     """
+    type = 'group'
 
     def __init__(self, api_resource=None):
         """
@@ -409,7 +423,6 @@ class Group(DSpaceObject):
         super().__init__(api_resource)
         self.name = None
         self.permanent = False
-        self.type = 'group'
 
         if api_resource is not None:
             self.name = api_resource.get('name')
@@ -429,6 +442,7 @@ class User(SimpleDSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and methods for users (aka. EPersons)
     """
+    type = "eperson"
 
     def __init__(self, api_resource=None):
         """
@@ -443,7 +457,6 @@ class User(SimpleDSpaceObject):
         self.email = None
         self.requireCertificate = False
         self.selfRegistered = False
-        self.type = 'user'
 
         if api_resource is not None:
             self.name = api_resource.get('name')
@@ -472,7 +485,6 @@ class InProgressSubmission(AddressableHALResource):
         self.lastModified = None
         self.step = None
         self.sections = {}
-        self.type = None
 
         if api_resource is not None:
             self.lastModified = api_resource.get('lastModified')
@@ -486,11 +498,11 @@ class InProgressSubmission(AddressableHALResource):
             'lastModified': self.lastModified,
             'step': self.step,
             'sections': self.sections,
-            'type': self.type
         }
         return {**parent_dict, **dict}
 
 class WorkspaceItem(InProgressSubmission):
+    type = 'workspaceitem'
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
@@ -504,10 +516,11 @@ class EntityType(AddressableHALResource):
     used in entities and relationships. For example, Publication, Person, Project and Journal
     are all common entity types used in DSpace 7+
     """
+    type = "entitytype"
+
     def __init__(self, api_resource):
         super().__init__(api_resource)
         self.label = None
-        self.type = 'entitytype' 
 
         if api_resource is not None:
             self.label = api_resource.get('label')
@@ -516,73 +529,27 @@ class RelationshipType(AddressableHALResource):
     """
     TODO: RelationshipType
     """
+    type = "relationshiptype"
+
     def __init__(self, api_resource):
         super().__init__(api_resource)
 
 class SearchResult(HALResource):
     """
-    {
-      "query":"my query",
-      "scope":"9076bd16-e69a-48d6-9e41-0238cb40d863",
-      "appliedFilters": [
-          {
-            "filter" : "title",
-            "operator" : "notcontains",
-            "value" : "abcd",
-            "label" : "abcd"
-          },
-          {
-            "filter" : "author",
-            "operator" : "authority",
-            "value" : "1234",
-            "label" : "Smith, Donald"
-          }
-      ],
-      "sort" : {
-        "by" : "dc.date.issued",
-        "order" : "asc"
-      },
-      "_embedded" : {
-        "searchResults": {
-          "_embedded": {
-            "objects" : [...],
-            },
-
-          "_links": {
-            "first": {
-              "href": "/api/discover/search/objects?query=my+query&scope=9076bd16-e69a-48d6-9e41-0238cb40d863&f.title=abcd,notcontains&f.author=1234,authority&page=0&size=5"
-            },
-            "self": {
-              "href": "/api/discover/search/objects?query=my+query&scope=9076bd16-e69a-48d6-9e41-0238cb40d863&f.title=abcd,notcontains&f.author=1234,authority&page=0&size=5"
-            },
-            "next": {
-              "href": "/api/discover/search/objects?query=my+query&scope=9076bd16-e69a-48d6-9e41-0238cb40d863&f.title=abcd,notcontains&f.author=1234,authority&page=1&size=5"
-            },
-            "last": {
-              "href": "/api/discover/search/objects?query=my+query&scope=9076bd16-e69a-48d6-9e41-0238cb40d863&f.title=abcd,notcontains&f.author=1234,authority&page=2&size=5"
-            }
-          },
-          "page": {
-            "number": 0,
-            "size": 20,
-            "totalElements": 12,
-            "totalPages": 3
-          }
-        }, "facets"... (TODO)
+    Discover search result 
     """
+    type = "discover"
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
         self.query = None
         self.scope = None
         self.appliedFilters = [] 
-        self.type = None
 
         if api_resource is not None:
             self.lastModified = api_resource.get('lastModified')
             self.step = api_resource.get('step')
             self.sections = api_resource.get('sections', {}).copy()
-            self.type = api_resource.get('type')
 
     def as_dict(self):
         parent_dict = super().__dict__
@@ -590,7 +557,6 @@ class SearchResult(HALResource):
             'lastModified': self.lastModified,
             'step': self.step,
             'sections': self.sections,
-            'type': self.type
         }
         return {**parent_dict, **dict}
 
@@ -599,10 +565,10 @@ class ResourcePolicy(AddressableHALResource):
     A resource policy to control access and authorization to DSpace objects
     See: https://github.com/DSpace/RestContract/blob/main/resourcepolicies.md
     """
+    type = "resourcepolicy"
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
-        self.type = 'resourcepolicy'
         self.name = None
         self.description = None
         self.policyType = None
@@ -620,7 +586,8 @@ class ResourcePolicy(AddressableHALResource):
 
     def as_dict(self):
         hal_dict = super().as_dict()
-        rp_dict = {'name': self.name, 'description': self.description, 'policyType': self.policyType, 'action': self.action, 'startDate': self.startDate, 'endDate': self.endDate}
+        rp_dict = {'name': self.name, 'description': self.description, 'policyType': self.policyType,
+                   'action': self.action, 'startDate': self.startDate, 'endDate': self.endDate}
         return {**hal_dict, **rp_dict}
 
 

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -13,7 +13,8 @@ import json
 from typing import Any
 
 __all__ = ['DSpaceObject', 'HALResource', 'ExternalDataObject', 'SimpleDSpaceObject', 'Community',
-           'Collection', 'Item', 'Bundle', 'Bitstream', 'BitstreamFormat', 'User', 'Group']
+           'Collection', 'Item', 'Bundle', 'Bitstream', 'BitstreamFormat', 'User', 'Group',
+           'WorkspaceItem', 'InProgressSubmission', 'SearchResult', 'EntityType', 'ResourcePolicy']
 
 
 class HALResource:
@@ -40,6 +41,9 @@ class HALResource:
         return {'type': self.type}
 
 class AddressableHALResource(HALResource):
+    """
+    Any DSpace resource with an identifier ('id' in serialised JSON)
+    """
     def __init__(self, api_resource=None):
         super().__init__(api_resource)
         self.id = None
@@ -57,6 +61,10 @@ class ExternalDataObject(AddressableHALResource):
     Generic External Data Object as configured in DSpace's external data providers framework
     TODO: this is also known as externalSourceEntry? Should the class name be modified or aliased?
     Or should we draw a subtle distinction between the two even if they share the same model
+
+    Java API Model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/external/model/ExternalDataObject.html
+    Java REST API Model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/ExternalSourceEntryRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/external-authority-sources.md
     """
     type = "externalSourceEntry"
 
@@ -220,8 +228,6 @@ class SimpleDSpaceObject(DSpaceObject):
 
 class Item(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for items.
-
     Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Item.html
     Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/ItemRest.html
     REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/items.md
@@ -270,8 +276,6 @@ class Item(SimpleDSpaceObject):
 
 class Community(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for communities.
-
     Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Community.html
     Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/CommunityRest.html
     REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/communities.md
@@ -298,8 +302,6 @@ class Community(SimpleDSpaceObject):
 
 class Collection(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for collections.
-
     Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Collection.html
     Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/CollectionRest.html
     REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/collections.md
@@ -325,8 +327,6 @@ class Collection(SimpleDSpaceObject):
 
 class Bundle(DSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for bundles.
-
     Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Bundle.html
     Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/BundleRest.html
     REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/bundles.md
@@ -352,8 +352,6 @@ class Bundle(DSpaceObject):
 
 class Bitstream(DSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for bitstreams.
-
     Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Bitstream.html
     Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/BitstreamRest.html
     REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/bitstreams.md

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -306,7 +306,7 @@ class Bundle(DSpaceObject):
     """
     Extends DSpaceObject to implement specific attributes and functions for bundles
     """
-    type = "collection"
+    type = "bundle"
 
     def __init__(self, api_resource=None):
         """
@@ -547,18 +547,19 @@ class SearchResult(HALResource):
         self.appliedFilters = [] 
 
         if api_resource is not None:
-            self.lastModified = api_resource.get('lastModified')
-            self.step = api_resource.get('step')
-            self.sections = api_resource.get('sections', {}).copy()
+            self.query = api_resource.get('query')
+            self.scope = api_resource.get('scope')
+            self.appliedFilters = api_resource.get('appliedFilters', []).copy()
 
     def as_dict(self):
-        parent_dict = super().__dict__
-        dict = {
-            'lastModified': self.lastModified,
-            'step': self.step,
-            'sections': self.sections,
+        parent_dict = super().as_dict()
+        this_dict = {
+            'query': self.query,
+            'scope': self.scope,
+            'appliedFilters': self.appliedFilters
         }
-        return {**parent_dict, **dict}
+
+        return {**parent_dict, **this_dict}
 
 class ResourcePolicy(AddressableHALResource):
     """

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -130,6 +130,14 @@ class DSpaceObject(AddressableHALResource):
             # alternatively - each item could implement getters, or a public method to return links
             self.links = api_resource.get('_links', {}).copy()
 
+    def get_metadata_values(self, field):
+        """
+        Return metadata values as simple list of strings
+        @param field: DSpace field, eg. dc.creator
+        @return: list of strings
+        """
+        return self.metadata.get(field, [])
+
     def add_metadata(self, field, value, language=None, authority=None, confidence=-1, place=None):
         """
         Add metadata to a DSO. This is performed on the local object only, it is not an API operation (see patch)
@@ -229,13 +237,7 @@ class Item(SimpleDSpaceObject):
             self.discoverable = api_resource.get('discoverable', False)
             self.withdrawn = api_resource.get('withdrawn', False)
 
-    def get_metadata_values(self, field):
-        """
-        Return metadata values as simple list of strings
-        @param field: DSpace field, eg. dc.creator
-        @return: list of strings
-        """
-        return self.metadata.get(field, [])
+
 
     def as_dict(self):
         """

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -10,6 +10,7 @@ when creating, updating, retrieving and deleting DSpace Objects.
 @author Kim Shepherd <kim@shepherd.nz>
 """
 import json
+from typing import Any
 
 __all__ = ['DSpaceObject', 'HALResource', 'ExternalDataObject', 'SimpleDSpaceObject', 'Community',
            'Collection', 'Item', 'Bundle', 'Bitstream', 'BitstreamFormat', 'User', 'Group']
@@ -35,7 +36,7 @@ class HALResource:
         else:
             self.links = {'self': {'href': None}}
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, Any]:
         return {'type': self.type}
 
 class AddressableHALResource(HALResource):
@@ -295,11 +296,11 @@ class Collection(SimpleDSpaceObject):
         super().__init__(api_resource)
 
     def as_dict(self):
-        dso_dict = super().as_dict()
         """
         Return a dict representation of this Collection, based on super with collection-specific attributes added
         @return: dict of Item for API use
         """
+        dso_dict = super().as_dict()
         collection_dict = {}
         return {**dso_dict, **collection_dict}
 
@@ -492,7 +493,6 @@ class InProgressSubmission(AddressableHALResource):
             self.lastModified = api_resource.get('lastModified')
             self.step = api_resource.get('step')
             self.sections = api_resource.get('sections', {}).copy()
-            self.lastModified = api_resource.get('lastModified')
 
     def as_dict(self):
         parent_dict = super().as_dict()

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -101,6 +101,9 @@ class DSpaceObject(AddressableHALResource):
     The variables here are present in an _embedded response and the ones required for POST / PUT / PATCH
     operations are included in the dict returned by asDict(). Implements toJSON() as well.
     This class can be used on its own but is generally expected to be extended by other types: Item, Bitstream, etc.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/DSpaceObject.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/DSpaceObjectRest.html
     """
 
     def __init__(self, api_resource=None, dso=None):
@@ -209,12 +212,19 @@ class SimpleDSpaceObject(DSpaceObject):
     """
     Objects that share similar simple API methods eg. PUT update for full metadata replacement, can have handles, etc.
     By default this is Item, Community, Collection classes
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/DSpaceObject.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/DSpaceObjectRest.html
     """
 
 
 class Item(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for items
+    Extends DSpaceObject to implement specific attributes and functions for items.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Item.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/ItemRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/items.md
     """
     type = "item"
 
@@ -260,7 +270,11 @@ class Item(SimpleDSpaceObject):
 
 class Community(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for communities
+    Extends DSpaceObject to implement specific attributes and functions for communities.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Community.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/CommunityRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/communities.md
     """
     type = 'community'
 
@@ -284,7 +298,11 @@ class Community(SimpleDSpaceObject):
 
 class Collection(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for collections
+    Extends DSpaceObject to implement specific attributes and functions for collections.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Collection.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/CollectionRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/collections.md
     """
     type = "collection"
 
@@ -307,7 +325,11 @@ class Collection(SimpleDSpaceObject):
 
 class Bundle(DSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for bundles
+    Extends DSpaceObject to implement specific attributes and functions for bundles.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Bundle.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/BundleRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/bundles.md
     """
     type = "bundle"
 
@@ -330,7 +352,11 @@ class Bundle(DSpaceObject):
 
 class Bitstream(DSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and functions for bundles
+    Extends DSpaceObject to implement specific attributes and functions for bitstreams.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/Bitstream.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/BitstreamRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/bitstreams.md
     """
     type = "bitstream"
 
@@ -367,19 +393,11 @@ class Bitstream(DSpaceObject):
 
 class BitstreamFormat(AddressableHALResource):
     """
-    Bitstream format: https://github.com/DSpace/RestContract/blob/main/bitstreamformats.md
-    example:
-        {
-          "shortDescription": "XML",
-          "description": "Extensible Markup Language",
-          "mimetype": "text/xml",
-          "supportLevel": "KNOWN",
-          "internal": false,
-          "extensions": [
-                  "xml"
-          ],
-          "type": "bitstreamformat"
-        }
+    Represents format / MIME metadata for a bitstream.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/BitstreamFormat.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/BitstreamFormatRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/bitstreamformats.md
     """
     type = "bitstreamformat"
 
@@ -414,7 +432,11 @@ class BitstreamFormat(AddressableHALResource):
 
 class Group(DSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and methods for groups (aka. EPersonGroups)
+    Extends DSpaceObject to implement specific attributes and methods for groups (aka. EPersonGroups).
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/eperson/Group.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/GroupRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/epersongroups.md
     """
     type = 'group'
 
@@ -443,7 +465,13 @@ class Group(DSpaceObject):
 
 class User(SimpleDSpaceObject):
     """
-    Extends DSpaceObject to implement specific attributes and methods for users (aka. EPersons)
+    Extends DSpaceObject to implement specific attributes and methods for users (aka. EPersons).
+    This is one class that is deliberately named differently to the base implementation, out of
+    protest ;) But perhaps it needs to be aliased or aligned with DSpace API for usability...
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/eperson/EPerson.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/EPersonRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/epersons.md
     """
     type = "eperson"
 
@@ -482,6 +510,15 @@ class User(SimpleDSpaceObject):
         return {**dso_dict, **user_dict}
 
 class InProgressSubmission(AddressableHALResource):
+    """
+    Extends AddressableHALResource to implement an 'in-progress' item (i.e. workspace or workflow item).
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/InProgressSubmission.html
+    Java REST API model (workspace): https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/WorkspaceItemRest.html
+    Java REST API model (workflow): https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/WorkflowItemRest.html
+    REST endpoint contract (workspace): https://github.com/DSpace/RestContract/blob/dspace-9.0/workspaceitems.md
+    REST endpoint contract (workflow): https://github.com/DSpace/RestContract/blob/dspace-9.0/workflowitems.md
+    """
 
     def __init__(self, api_resource):
         super().__init__(api_resource)
@@ -504,6 +541,13 @@ class InProgressSubmission(AddressableHALResource):
         return {**parent_dict, **dict}
 
 class WorkspaceItem(InProgressSubmission):
+    """
+    Extends InProgressSubmission to implement a WorkspaceItem.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/WorkspaceItem.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/WorkspaceItemRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/workspaceitems.md
+    """
     type = 'workspaceitem'
 
     def __init__(self, api_resource):
@@ -514,9 +558,12 @@ class WorkspaceItem(InProgressSubmission):
 
 class EntityType(AddressableHALResource):
     """
-    Extends Addressable HAL Resource to model an entity type (aka item type)
-    used in entities and relationships. For example, Publication, Person, Project and Journal
-    are all common entity types used in DSpace 7+
+    Extends Addressable HAL Resource to model an entity type (aka item type) used in entities and relationships.
+    For example, Publication, Person, Project and Journal are all common entity types used in DSpace 7+
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/EntityType.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/EntityTypeRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/entitytypes.md
     """
     type = "entitytype"
 
@@ -529,7 +576,13 @@ class EntityType(AddressableHALResource):
 
 class RelationshipType(AddressableHALResource):
     """
-    TODO: RelationshipType
+    TODO! Not yet implemented
+    Extends Addressable HAL Resource to model a relationship type.
+    For example, isAuthorOfPublication.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/content/RelationshipType.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/RelationshipTypeRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/relationshiptypes.md
     """
     type = "relationshiptype"
 
@@ -538,7 +591,11 @@ class RelationshipType(AddressableHALResource):
 
 class SearchResult(HALResource):
     """
-    Discover search result 
+    A 'Discover' search result, which can embed any kind of addressable object managed by DSpace.
+
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/discover/DiscoverResult.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/SearchResultRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/search-endpoint.md
     """
     type = "discover"
 
@@ -565,8 +622,10 @@ class SearchResult(HALResource):
 
 class ResourcePolicy(AddressableHALResource):
     """
-    A resource policy to control access and authorization to DSpace objects
-    See: https://github.com/DSpace/RestContract/blob/main/resourcepolicies.md
+    A resource policy to control access and authorization to DSpace objects.
+    Java API model: https://javadoc.io/doc/org.dspace/dspace-api/9.0/org/dspace/authorize/ResourcePolicy.html
+    Java REST API model: https://javadoc.io/doc/org.dspace/dspace-server-webapp/9.0/org/dspace/app/rest/model/ResourcePolicyRest.html
+    REST endpoint contract: https://github.com/DSpace/RestContract/blob/dspace-9.0/resourcepolicies.md
     """
     type = "resourcepolicy"
 

--- a/dspace_rest_client/models.py
+++ b/dspace_rest_client/models.py
@@ -488,7 +488,7 @@ class InProgressSubmission(AddressableHALResource):
 
         if api_resource is not None:
             self.lastModified = api_resource.get('lastModified')
-            self.step = api_resource.get('lastModified')
+            self.step = api_resource.get('step')
             self.sections = api_resource.get('sections', {}).copy()
             self.lastModified = api_resource.get('lastModified')
 


### PR DESCRIPTION
Client changes:

* Keep `session` as an instance var in client
* Remove unused `verbose` CLI option
* Switch order of args used with `do_paginate` to satisfy static analysis where `self` as first arg is expected
* Use direct access in Headers["Auth.."] as key was already checked
* Always check JSON response object for None before accessing keys (this can be further improved with real error handling, but for now at least applies None checks consistently)

Model changes:

* Simplify and improve all `__init__` methods with dict get accessors and default values
* Move class-level variables to instance where appropriate
* Enforce `type` var as class level hard-coded string on all Models (justification: we have modelled the Python data model on the expected type with that label, we don't want to overwrite it with "whatever comes back from the REST API", unless checking for errors, right?)
* Improve PyDoc by removing self-explanatory "This extends {name of superclass}" comments and adding useful URL references to DSpace Javadoc and REST contract docs
* Add all implemented classes to the models `__all__` list